### PR TITLE
IOS-4520 Fix passcode lth 2nd

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -125,10 +125,6 @@
  */
 @property (nonatomic, assign) CGFloat failedAttemptLabelGap;
 /**
- @brief The gap between the failed label and the options button.
- */
-@property (nonatomic, assign) CGFloat optionsButtonGap;
-/**
  @brief The height for the complex passcode overlay.
  */
 @property (nonatomic, assign) CGFloat passcodeOverlayHeight;

--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -201,10 +201,6 @@
  */
 @property (nonatomic, strong) UIColor *optionsButtonTextColor;
 /**
- @brief The text color for the cancel button.
- */
-@property (nonatomic, strong) UIColor *cancelButtonTextColor;
-/**
  @brief The border color for the textFiled.
  */
 @property (nonatomic, strong) UIColor *textFieldBorderColor;

--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -205,6 +205,10 @@
  */
 @property (nonatomic, strong) UIColor *cancelButtonTextColor;
 /**
+ @brief The border color for the textFiled.
+ */
+@property (nonatomic, strong) UIColor *textFieldBorderColor;
+/**
  @brief The tint color to apply to the navigation items and bar button items.
  */
 @property (nonatomic, strong) UIColor *navigationBarTintColor;

--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -125,6 +125,10 @@
  */
 @property (nonatomic, assign) CGFloat failedAttemptLabelGap;
 /**
+ @brief The gap between the passcode button and the keyboard.
+ */
+@property (nonatomic, assign) CGFloat passcodeButtonGap;
+/**
  @brief The height for the complex passcode overlay.
  */
 @property (nonatomic, assign) CGFloat passcodeOverlayHeight;

--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -197,9 +197,13 @@
  */
 @property (nonatomic, strong) UIColor *eraseLocalDataLabelTextColor;
 /**
- @brief The text color for the options.
+ @brief The text color for the options button.
  */
-@property (nonatomic, strong) UIColor *optionsTextColor;
+@property (nonatomic, strong) UIColor *optionsButtonTextColor;
+/**
+ @brief The text color for the cancel button.
+ */
+@property (nonatomic, strong) UIColor *cancelButtonTextColor;
 /**
  @brief The tint color to apply to the navigation items and bar button items.
  */

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -743,6 +743,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _complexPasscodeOverlayView = [[UIView alloc] initWithFrame:CGRectZero];
     _complexPasscodeOverlayView.backgroundColor = UIColor.mnz_background;
     _complexPasscodeOverlayView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self _setupPasscodeOverlayBorder];
     
     _simplePasscodeView = [[UIView alloc] initWithFrame:CGRectZero];
     _simplePasscodeView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -878,7 +879,6 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     }
     else {
         [_complexPasscodeOverlayView addSubview:_passcodeTextField];
-        [self _setupPasscodeOverlayBorder];
         
         // If we come from simple state some constraints are added even if
         // translatesAutoresizingMaskIntoConstraints = NO,
@@ -2126,6 +2126,7 @@ UIInterfaceOrientationMask UIInterfaceOrientationMaskFromOrientation(UIInterface
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context){}
                                  completion:^(id<UIViewControllerTransitionCoordinatorContext> context){
         self.complexPasscodeOverlayView.layer.sublayers = nil;
+        [self _setupPasscodeOverlayBorder];
         [self.view setNeedsUpdateConstraints];
     }];
 }

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -189,8 +189,6 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
         _passcodeType = (PasscodeType)[[LTHKeychainUtils getPasswordForUsername:_keychainPasscodeTypeUsername
                                                andServiceName:_keychainServiceName
                                                         error:nil] integerValue];
-    } else {
-        _passcodeType = PasscodeTypeFourDigits;
     }
     
     if (_isSimple) {
@@ -292,6 +290,12 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     }
     
     [LTHKeychainUtils deleteItemForUsername:_keychainPasscodeUsername
+                             andServiceName:_keychainServiceName
+                                      error:nil];
+    [LTHKeychainUtils deleteItemForUsername:_keychainPasscodeTypeUsername
+                             andServiceName:_keychainServiceName
+                                      error:nil];
+    [LTHKeychainUtils deleteItemForUsername:_keychainPasscodeIsSimpleUsername
                              andServiceName:_keychainServiceName
                                       error:nil];
 }
@@ -1718,7 +1722,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     // Add all the buttons
     for (NSInteger i = 0; i < types.count; i++) {
         PasscodeType type = [types[i] integerValue];
-        if (type == self.passcodeType) { continue; }
+        if (type == _passcodeType) { continue; }
 
         id handler = ^(UIAlertAction *action) {
             [weakSelf setPasscodeTypeAndInputArea:type];
@@ -1740,7 +1744,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 
 #pragma mark - Notification Observers
 - (void)_applicationDidEnterBackground {
-    if ([self _doesPasscodeExist]) {
+    if ([self _passcode].length != 0) {
         if ([_passcodeTextField isFirstResponder]) {
             _useFallbackPasscode = NO;
             [_passcodeTextField resignFirstResponder];
@@ -1770,7 +1774,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 
 
 - (void)_applicationWillEnterForeground {
-    if ([self _doesPasscodeExist] &&
+    if ([self _passcode].length != 0 &&
         [self _didPasscodeTimerEnd]) {
         _useFallbackPasscode = NO;
         
@@ -1792,7 +1796,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 
 
 - (void)_applicationWillResignActive {
-    if ([self _doesPasscodeExist] && !([self isCurrentlyOnScreen] && [self displayedAsLockScreen])) {
+    if ([self _passcode].length != 0 && !([self isCurrentlyOnScreen] && [self displayedAsLockScreen])) {
         _useFallbackPasscode = NO;
         [self _saveTimerStartTime];
     }

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -599,6 +599,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     if (@available(iOS 13.0, *)) {
         if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
             [AppearanceManager forceNavigationBarUpdate:self.navigationController.navigationBar traitCollection:self.traitCollection];
+            self.view.backgroundColor = [UIColor mnz_mainBarsForTraitCollection:self.traitCollection];
         }
     }
 }
@@ -1728,7 +1729,6 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 
     // Cancel button
     UIAlertAction* cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil];
-    [cancel setValue:_cancelButtonTextColor forKey:@"titleTextColor"];
     [alertController addAction:cancel];
     
     alertController.modalPresentationStyle = UIModalPresentationPopover;
@@ -1915,7 +1915,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 
 - (void)_loadColorDefaults {
     // Backgrounds
-    _backgroundColor = UIColor.mnz_background;
+    _backgroundColor = [UIColor mnz_mainBarsForTraitCollection:self.traitCollection];
     _passcodeBackgroundColor = [UIColor clearColor];
     _coverViewBackgroundColor = UIColor.mnz_background;
     _failedAttemptLabelBackgroundColor =  UIColor.mnz_redError;
@@ -1928,7 +1928,6 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _failedAttemptLabelTextColor = UIColor.mnz_background;
     _eraseLocalDataLabelTextColor = UIColor.mnz_redError;
     _optionsButtonTextColor = [UIColor colorWithRed:0 green:168.0/255.0 blue:134.0/255.0 alpha:1.0];
-    _cancelButtonTextColor = UIColor.mnz_label;
     _textFieldBorderColor = [UIColor colorWithRed:60.0/255.0 green:60.0/255.0 blue:67.0/255.0 alpha:0.3];
 }
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1363,19 +1363,22 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                                                                     withString: string];
     
     if (self.isSimple) {
-        
-        [_digitTextFieldsArray enumerateObjectsUsingBlock:^(UITextField * _Nonnull textField, NSUInteger idx, BOOL * _Nonnull stop) {
-            textField.secureTextEntry = typedString.length > idx;
-        }];
-        
-        if (typedString.length == _digitsCount) {
-            // Make the last bullet show up
-            [self performSelector: @selector(_validatePasscode:)
-                       withObject: typedString
-                       afterDelay: 0.15];
+        if ([string rangeOfCharacterFromSet:[NSCharacterSet decimalDigitCharacterSet].invertedSet].location != NSNotFound) {
+            return NO;
+        } else {
+            [_digitTextFieldsArray enumerateObjectsUsingBlock:^(UITextField * _Nonnull textField, NSUInteger idx, BOOL * _Nonnull stop) {
+                textField.secureTextEntry = typedString.length > idx;
+            }];
+            
+            if (typedString.length == _digitsCount) {
+                // Make the last bullet show up
+                [self performSelector: @selector(_validatePasscode:)
+                           withObject: typedString
+                           afterDelay: 0.15];
+            }
+            
+            if (typedString.length > _digitsCount) return NO;
         }
-        
-        if (typedString.length > _digitsCount) return NO;
     }
     
     return YES;

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -838,7 +838,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 
 - (void)_setupOptionsButton {
     _optionsButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [_optionsButton setTitle:NSLocalizedString(@"Passcode Options", @"") forState:UIControlStateNormal];
+    [_optionsButton setTitle:NSLocalizedString(@"Passcode Options", @"Button text to change the passcode type.") forState:UIControlStateNormal];
     _optionsButton.titleLabel.font = _optionsButtonFont;
     [_optionsButton setTitleColor:_optionsButtonTextColor forState:UIControlStateNormal];
     [_optionsButton sizeToFit];
@@ -1711,7 +1711,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                       ];
 
 
-    NSArray *titles = @[NSLocalizedString(@"4-Digit Numeric Code", @""),
+    NSArray *titles = @[NSLocalizedString(@"4-Digit Numeric Code", @"Action text to change to 4-Digit Numeric passcode type."),
                         NSLocalizedString(@"6-Digit Numeric Code", @""),
                         NSLocalizedString(@"Custom Alphanumeric Code", @"")];
 
@@ -1735,7 +1735,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     }
 
     // Cancel button
-    UIAlertAction* cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil];
+    UIAlertAction* cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"cancel", @"Button title to cancel something") style:UIAlertActionStyleCancel handler:nil];
     [alertController addAction:cancel];
     
     alertController.modalPresentationStyle = UIModalPresentationPopover;

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -179,8 +179,6 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
         _isSimple = [[LTHKeychainUtils getPasswordForUsername:_keychainPasscodeIsSimpleUsername
                                                andServiceName:_keychainServiceName
                                                         error:nil] boolValue];
-    } else {
-        _isSimple = YES;
     }
     
     if ([LTHKeychainUtils getPasswordForUsername:_keychainPasscodeTypeUsername
@@ -618,6 +616,9 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _isUserEnablingPasscode = NO;
     _isUserTurningPasscodeOff = NO;
     _isUserSwitchingBetweenPasscodeModes = NO;
+    // reset to previous passcode type
+    [self _doesPasscodeExist];
+    [self.view setNeedsUpdateConstraints];
     [self _resetUI];
     [_passcodeTextField resignFirstResponder];
     
@@ -1590,7 +1591,6 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 
 
 - (void)_resetUI {
-    [self _setupDigitFields];
     [self _resetTextFields];
     _failedAttemptLabel.backgroundColor	= _failedAttemptLabelBackgroundColor;
     _failedAttemptLabel.textColor = _failedAttemptLabelTextColor;

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1656,7 +1656,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _failedAttemptLabel.backgroundColor = [UIColor clearColor];
     _failedAttemptLabel.layer.borderWidth = 0;
     _failedAttemptLabel.layer.borderColor = [UIColor clearColor].CGColor;
-    _failedAttemptLabel.textColor = _labelTextColor;
+    _failedAttemptLabel.textColor = UIColor.mnz_redError;
     _eraseLocalDataLabel.hidden = YES;
     _optionsButton.hidden = NO;
 }

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -737,8 +737,6 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _complexPasscodeOverlayView = [[UIView alloc] initWithFrame:CGRectZero];
     _complexPasscodeOverlayView.backgroundColor = UIColor.mnz_background;
     _complexPasscodeOverlayView.translatesAutoresizingMaskIntoConstraints = NO;
-    _complexPasscodeOverlayView.layer.borderWidth = 1;
-    _complexPasscodeOverlayView.layer.borderColor = [UIColor colorWithRed:60.0/255.0 green:60.0/255.0 blue:67.0/255.0 alpha:0.3].CGColor;
     
     _simplePasscodeView = [[UIView alloc] initWithFrame:CGRectZero];
     _simplePasscodeView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -841,6 +839,18 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _optionsButton.translatesAutoresizingMaskIntoConstraints = NO;
 }
 
+- (void)_setupPasscodeOverlayBorder {
+    CALayer *topBorder = [CALayer layer];
+    topBorder.frame = CGRectMake(0, 0, self.view.frame.size.width, 1);
+    topBorder.backgroundColor = _textFieldBorderColor.CGColor;
+    [_complexPasscodeOverlayView.layer addSublayer:topBorder];
+
+    CALayer *bottomBorder = [CALayer layer];
+    bottomBorder.frame = CGRectMake(0, _passcodeOverlayHeight - 1, self.view.frame.size.width, 1);
+    bottomBorder.backgroundColor = _textFieldBorderColor.CGColor;
+    [_complexPasscodeOverlayView.layer addSublayer:bottomBorder];
+}
+
 - (void)updateViewConstraints {
     [super updateViewConstraints];
     [self.view removeConstraints:self.view.constraints];
@@ -862,6 +872,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     }
     else {
         [_complexPasscodeOverlayView addSubview:_passcodeTextField];
+        [self _setupPasscodeOverlayBorder];
         
         // If we come from simple state some constraints are added even if
         // translatesAutoresizingMaskIntoConstraints = NO,
@@ -1917,6 +1928,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _eraseLocalDataLabelTextColor = UIColor.mnz_redError;
     _optionsButtonTextColor = [UIColor colorWithRed:0 green:168.0/255.0 blue:134.0/255.0 alpha:1.0];
     _cancelButtonTextColor = [UIColor mnz_primaryGrayForTraitCollection:self.traitCollection];
+    _textFieldBorderColor = [UIColor colorWithRed:60.0/255.0 green:60.0/255.0 blue:67.0/255.0 alpha:0.3];
 }
 
 
@@ -2110,6 +2122,7 @@ UIInterfaceOrientationMask UIInterfaceOrientationMaskFromOrientation(UIInterface
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context){}
                                  completion:^(id<UIViewControllerTransitionCoordinatorContext> context){
         [self.view setNeedsUpdateConstraints];
+        self.complexPasscodeOverlayView.layer.sublayers = nil;
     }];
 }
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -79,6 +79,7 @@ options:NSNumericSearch] != NSOrderedAscending)
 
 @property (nonatomic, assign) CGFloat     modifierForBottomVerticalGap;
 @property (nonatomic, assign) CGFloat     fontSizeModifier;
+@property (nonatomic, assign) CGFloat     keyboardHeight;
 
 @property (nonatomic, assign) BOOL        newPasscodeEqualsOldPasscode;
 @property (nonatomic, assign) BOOL        passcodeAlreadyExists;
@@ -508,6 +509,10 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     [self setIsSimple:!(passcodeType == PasscodeTypeCustomAlphanumeric) inViewController:nil asModal:self.displayedAsModal];
 }
 
+- (void)keyboardWillChangeFrame:(NSNotification *)notification {
+    _keyboardHeight = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue].size.height;
+}
+
 #pragma mark - View life
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -538,6 +543,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _passcodeTextField.returnKeyType = UIReturnKeyGo;
     
     [self.view setNeedsUpdateConstraints];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillChangeFrame:) name:UIKeyboardWillChangeFrameNotification object:nil];
 }
 
 
@@ -1103,16 +1109,16 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                                  attribute: NSLayoutAttributeCenterX
                                 multiplier: 1.0f
                                   constant: 0.0f];
-    NSLayoutConstraint *optionsButtonConstraintCenterY =
+    NSLayoutConstraint *optionsButtonConstraintBottom =
     [NSLayoutConstraint constraintWithItem: _optionsButton
-                                 attribute: NSLayoutAttributeCenterY
+                                 attribute: NSLayoutAttributeBottom
                                  relatedBy: NSLayoutRelationEqual
-                                    toItem: _failedAttemptLabel
-                                 attribute: NSLayoutAttributeCenterY
+                                    toItem: self.view
+                                 attribute: NSLayoutAttributeBottom
                                 multiplier: 1.0f
-                                  constant: _optionsButtonGap];
+                                  constant: -(_keyboardHeight + _verticalGap)];
     [self.view addConstraint: optionsButtonConstraintCenterX];
-    [self.view addConstraint: optionsButtonConstraintCenterY];
+    [self.view addConstraint: optionsButtonConstraintBottom];
 }
 
 
@@ -1880,7 +1886,6 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _verticalGap = LTHiPad ? 60.0f : 25.0f;
     _modifierForBottomVerticalGap = LTHiPad ? 2.6f : 3.0f;
     _failedAttemptLabelGap = _verticalGap * _modifierForBottomVerticalGap - 2.0f;
-    _optionsButtonGap = _verticalGap * _modifierForBottomVerticalGap - 2.0f;
     _passcodeOverlayHeight = LTHiPad ? 96.0f : 40.0f;
 }
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -541,6 +541,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _passcodeTextField.delegate = self;
     _passcodeTextField.translatesAutoresizingMaskIntoConstraints = NO;
     _passcodeTextField.returnKeyType = UIReturnKeyGo;
+    _passcodeTextField.enablesReturnKeyAutomatically = YES;
     
     [self.view setNeedsUpdateConstraints];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillChangeFrame:) name:UIKeyboardWillChangeFrameNotification object:nil];

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -81,6 +81,8 @@ options:NSNumericSearch] != NSOrderedAscending)
 @property (nonatomic, assign) CGFloat     fontSizeModifier;
 @property (nonatomic, assign) CGFloat     keyboardHeight;
 
+@property (nonatomic, assign) NSLayoutConstraint *optionsButtonConstraintBottom;
+
 @property (nonatomic, assign) BOOL        newPasscodeEqualsOldPasscode;
 @property (nonatomic, assign) BOOL        passcodeAlreadyExists;
 @property (nonatomic, assign) BOOL        usesKeychain;
@@ -511,8 +513,18 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     [self setIsSimple:!(passcodeType == PasscodeTypeCustomAlphanumeric) inViewController:nil asModal:self.displayedAsModal];
 }
 
-- (void)keyboardWillChangeFrame:(NSNotification *)notification {
+- (void)keyboardHasHeight:(NSNotification *)notification {
     _keyboardHeight = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue].size.height;
+    [self setUpOptionButtonLocation];
+}
+
+- (void)keyboardNoHeight:(NSNotification *)notification {
+    _keyboardHeight = 0;
+    [self setUpOptionButtonLocation];
+}
+
+- (void)setUpOptionButtonLocation {
+    _optionsButtonConstraintBottom.constant = self.view.frame.size.height - _keyboardHeight - _verticalGap - _optionsButton.frame.size.height;
 }
 
 #pragma mark - View life
@@ -546,7 +558,8 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _passcodeTextField.enablesReturnKeyAutomatically = YES;
     
     [self.view setNeedsUpdateConstraints];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillChangeFrame:) name:UIKeyboardWillChangeFrameNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardHasHeight:) name:UIKeyboardWillShowNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardNoHeight:) name:UIKeyboardWillHideNotification object:nil];
 }
 
 
@@ -1127,7 +1140,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                                  attribute: NSLayoutAttributeCenterX
                                 multiplier: 1.0f
                                   constant: 0.0f];
-    NSLayoutConstraint *optionsButtonConstraintBottom =
+    _optionsButtonConstraintBottom =
     [NSLayoutConstraint constraintWithItem: _optionsButton
                                  attribute: NSLayoutAttributeTop
                                  relatedBy: NSLayoutRelationEqual
@@ -1136,7 +1149,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                                 multiplier: 1.0f
                                   constant: self.view.frame.size.height - _keyboardHeight - _verticalGap - _optionsButton.frame.size.height];
     [self.view addConstraint: optionsButtonConstraintCenterX];
-    [self.view addConstraint: optionsButtonConstraintBottom];
+    [self.view addConstraint: _optionsButtonConstraintBottom];
 }
 
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -2121,8 +2121,8 @@ UIInterfaceOrientationMask UIInterfaceOrientationMaskFromOrientation(UIInterface
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context){}
                                  completion:^(id<UIViewControllerTransitionCoordinatorContext> context){
-        [self.view setNeedsUpdateConstraints];
         self.complexPasscodeOverlayView.layer.sublayers = nil;
+        [self.view setNeedsUpdateConstraints];
     }];
 }
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -834,7 +834,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _optionsButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [_optionsButton setTitle:NSLocalizedString(@"Passcode Options", @"") forState:UIControlStateNormal];
     _optionsButton.titleLabel.font = _optionsButtonFont;
-    [_optionsButton setTitleColor:_optionsTextColor forState:UIControlStateNormal];
+    [_optionsButton setTitleColor:_optionsButtonTextColor forState:UIControlStateNormal];
     [_optionsButton sizeToFit];
     [_optionsButton addTarget:self action:@selector(optionsCodeButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
     [_animatingView addSubview:self.optionsButton];
@@ -1711,13 +1711,12 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
             [weakSelf setPasscodeTypeAndInputArea:type];
         };
         UIAlertAction* action = [UIAlertAction actionWithTitle:titles[i] style:style handler:handler];
-        [action setValue:_optionsTextColor forKey:@"titleTextColor"];
         [alertController addAction:action];
     }
 
     // Cancel button
     UIAlertAction* cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil];
-    [cancel setValue:_optionsTextColor forKey:@"titleTextColor"];
+    [cancel setValue:_cancelButtonTextColor forKey:@"titleTextColor"];
     [alertController addAction:cancel];
     
     alertController.modalPresentationStyle = UIModalPresentationPopover;
@@ -1916,7 +1915,8 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _passcodeTextColor = UIColor.mnz_label;
     _failedAttemptLabelTextColor = UIColor.mnz_background;
     _eraseLocalDataLabelTextColor = UIColor.mnz_redError;
-    _optionsTextColor = [UIColor colorWithRed:0 green:168.0/255.0 blue:134.0/255.0 alpha:1.0];
+    _optionsButtonTextColor = [UIColor colorWithRed:0 green:168.0/255.0 blue:134.0/255.0 alpha:1.0];
+    _cancelButtonTextColor = [UIColor mnz_primaryGrayForTraitCollection:self.traitCollection];
 }
 
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -798,7 +798,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     
     _eraseLocalDataLabel = [[UILabel alloc] initWithFrame: CGRectZero];
     _eraseLocalDataLabel.text = NSLocalizedString(@"failedAttempstSectionTitle", @"Footer text that explain what will happen if reach the max number of failed attempts");
-    _eraseLocalDataLabel.numberOfLines = 2;
+    _eraseLocalDataLabel.numberOfLines = 3;
     _eraseLocalDataLabel.backgroundColor = _eraseLocalDataLabelBackgroundColor;
     _eraseLocalDataLabel.hidden = YES;
     _eraseLocalDataLabel.textColor = _eraseLocalDataLabelTextColor;
@@ -910,7 +910,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
         _verticalOffset = -65;
         _passcodeButtonGap = 0;
     } else {
-        _verticalOffset = 0;
+        _verticalOffset = -5;
         _passcodeButtonGap = _verticalGap;
     }
     
@@ -1127,7 +1127,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                                     toItem: _failedAttemptLabel
                                  attribute: NSLayoutAttributeBottom
                                 multiplier: 1.0f
-                                  constant: _verticalGap];
+                                  constant: _verticalGap + 5];
     NSLayoutConstraint *eraseLocalDataLabelLeading =
     [NSLayoutConstraint constraintWithItem: _eraseLocalDataLabel
                                  attribute: NSLayoutAttributeLeading

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -892,7 +892,6 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     }
     else {
         [_complexPasscodeOverlayView addSubview:_passcodeTextField];
-        [self _setupPasscodeOverlayBorder];
         
         // If we come from simple state some constraints are added even if
         // translatesAutoresizingMaskIntoConstraints = NO,

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1111,12 +1111,12 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                                   constant: 0.0f];
     NSLayoutConstraint *optionsButtonConstraintBottom =
     [NSLayoutConstraint constraintWithItem: _optionsButton
-                                 attribute: NSLayoutAttributeBottom
+                                 attribute: NSLayoutAttributeTop
                                  relatedBy: NSLayoutRelationEqual
                                     toItem: self.view
-                                 attribute: NSLayoutAttributeBottom
+                                 attribute: NSLayoutAttributeTop
                                 multiplier: 1.0f
-                                  constant: -(_keyboardHeight + _verticalGap)];
+                                  constant: self.view.frame.size.height - _keyboardHeight - _verticalGap - _optionsButton.frame.size.height];
     [self.view addConstraint: optionsButtonConstraintCenterX];
     [self.view addConstraint: optionsButtonConstraintBottom];
 }
@@ -2105,5 +2105,12 @@ UIInterfaceOrientationMask UIInterfaceOrientationMaskFromOrientation(UIInterface
     return 1 << orientation;
 }
 
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context){}
+                                 completion:^(id<UIViewControllerTransitionCoordinatorContext> context){
+        [self.view setNeedsUpdateConstraints];
+    }];
+}
 
 @end

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1914,7 +1914,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 
 - (void)_loadColorDefaults {
     // Backgrounds
-    _backgroundColor = [UIColor mnz_mainBarsForTraitCollection:self.traitCollection];
+    _backgroundColor = UIColor.mnz_background;
     _passcodeBackgroundColor = [UIColor clearColor];
     _coverViewBackgroundColor = UIColor.mnz_background;
     _failedAttemptLabelBackgroundColor =  UIColor.mnz_redError;
@@ -1927,7 +1927,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     _failedAttemptLabelTextColor = UIColor.mnz_background;
     _eraseLocalDataLabelTextColor = UIColor.mnz_redError;
     _optionsButtonTextColor = [UIColor colorWithRed:0 green:168.0/255.0 blue:134.0/255.0 alpha:1.0];
-    _cancelButtonTextColor = [UIColor mnz_primaryGrayForTraitCollection:self.traitCollection];
+    _cancelButtonTextColor = UIColor.mnz_label;
     _textFieldBorderColor = [UIColor colorWithRed:60.0/255.0 green:60.0/255.0 blue:67.0/255.0 alpha:0.3];
 }
 


### PR DESCRIPTION
Fix failed test cases.
* Broken landscape layout.
* Broken light / dark mode.
* Wrong label color and text.
* Allow blank passcode.
* Number passcode allow alphabets.
* Keyboard not dismissing after input correct passcode.
* Changed passcode type doesn't stay after go to the background and return.

https://testrail.systems.mega.nz/index.php?/runs/view/376&group_by=cases:section_id&group_order=asc

https://github.com/meganz/iOS_dev/pull/1239
