### PR TITLE
fix(passcode): miss input field when first launch

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -575,9 +575,9 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     if ([self _doesPasscodeExist]) {
         if (_isSimple) {
             _digitsCount = [self _passcode].length;
-            [self _setupDigitFields];
         }
     }
+    [self _setupDigitFields];
     
     _passcodeTextField = [[UITextField alloc] initWithFrame: CGRectZero];
     _passcodeTextField.textAlignment = NSTextAlignmentCenter;


### PR DESCRIPTION
https://testrail.systems.mega.nz/index.php?/tests/view/1330455