### PR TITLE
IOS-4681: fix behaviour when in landscape on the iphone

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -542,7 +542,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 - (void)calculateOffsetGap {
     UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
     if (UIDeviceOrientationIsLandscape(orientation)) {
-        _verticalOffset = LTHiPad? -110 : -65;
+        _verticalOffset = LTHiPad? -110 : -25;
         _passcodeButtonGap = 0;
     } else {
         _verticalOffset = -5;


### PR DESCRIPTION
Fix case when label was clipped in the landscape orientation