### PR TITLE
IOS-7679:  Fixes wrong text displayed in the PasscodeViewController

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -307,6 +307,10 @@
  */
 @property (nonatomic, strong) NSString *biometricsDetailsString;
 /**
+ @brief The string displayed when a user tries to logout.
+ */
+@property (nonatomic, strong) NSString *logoutWarningMessageString;
+/**
  @brief The duration of the lock animation.
  */
 @property (nonatomic, assign) CGFloat lockAnimationDuration;

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -830,7 +830,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     [_animatingView addSubview: _failedAttemptLabel];
     
     _eraseLocalDataLabel = [[UILabel alloc] initWithFrame: CGRectZero];
-    _eraseLocalDataLabel.text = NSLocalizedString(@"failedAttempstSectionTitle", @"Footer text that explain what will happen if reach the max number of failed attempts");
+    _eraseLocalDataLabel.text = LTHPasscodeViewControllerStrings(@"failedAttempstSectionTitle");
     _eraseLocalDataLabel.numberOfLines = 3;
     _eraseLocalDataLabel.backgroundColor = _eraseLocalDataLabelBackgroundColor;
     _eraseLocalDataLabel.hidden = YES;
@@ -883,7 +883,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 
 - (void)_setupOptionsButton {
     _optionsButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [_optionsButton setTitle:NSLocalizedString(@"Passcode Options", @"Button text to change the passcode type.") forState:UIControlStateNormal];
+    [_optionsButton setTitle: LTHPasscodeViewControllerStrings(@"Passcode Options") forState:UIControlStateNormal];
     _optionsButton.titleLabel.font = _optionsButtonFont;
     [_optionsButton setTitleColor:_optionsButtonTextColor forState:UIControlStateNormal];
     [_optionsButton sizeToFit];
@@ -1617,9 +1617,9 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 - (void)_logoutWasPressed {
     // Notify delegate that logout button was pressed
     if ([self.delegate respondsToSelector: @selector(logoutButtonWasPressed)]) {
-        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"proceedToLogout", @"Title to confirm that you want to logout") message:NSLocalizedString(@"When you logout, files from your Offline section will be deleted from your device and ongoing transfers will be cancelled.", @"Warning message to alert user about logout in My Account section if has offline files and transfers in progress.") preferredStyle:UIAlertControllerStyleAlert];
-        [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"cancel", @"Button title to cancel something") style:UIAlertActionStyleCancel handler:nil]];
-        [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"logoutLabel", @"Title of the button which logs out from your account.") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:LTHPasscodeViewControllerStrings(@"proceedToLogout") message:LTHPasscodeViewControllerStrings(self.logoutWarningMessageString) preferredStyle:UIAlertControllerStyleAlert];
+        [alertController addAction:[UIAlertAction actionWithTitle:LTHPasscodeViewControllerStrings(@"cancel") style:UIAlertActionStyleCancel handler:nil]];
+        [alertController addAction:[UIAlertAction actionWithTitle:LTHPasscodeViewControllerStrings(@"logoutLabel") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             [self.delegate logoutButtonWasPressed];
         }]];
         [self presentViewController:alertController animated:YES completion:nil];
@@ -1763,10 +1763,9 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                        @(PasscodeTypeCustomAlphanumeric)
     ];
     
-    
-    NSArray *titles = @[NSLocalizedString(@"4-Digit Numeric Code", @"Action text to change to 4-Digit Numeric passcode type."),
-                        NSLocalizedString(@"6-Digit Numeric Code", @""),
-                        NSLocalizedString(@"Custom Alphanumeric Code", @"")];
+    NSArray *titles = @[LTHPasscodeViewControllerStrings(@"4-Digit Numeric Code"),
+                        LTHPasscodeViewControllerStrings(@"6-Digit Numeric Code"),
+                        LTHPasscodeViewControllerStrings(@"Custom Alphanumeric Code")];
     
     // Set current passcodeType based on current displayed passcode input area, to determin action options
     if (_passcodeTextField.hidden) {
@@ -1788,7 +1787,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     }
     
     // Cancel button
-    UIAlertAction* cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"cancel", @"Button title to cancel something") style:UIAlertActionStyleCancel handler:nil];
+    UIAlertAction* cancel = [UIAlertAction actionWithTitle:LTHPasscodeViewControllerStrings(@"cancel") style:UIAlertActionStyleCancel handler:nil];
     [alertController addAction:cancel];
     
     alertController.modalPresentationStyle = UIModalPresentationPopover;
@@ -1955,6 +1954,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     self.reenterNewPasscodeString = @"Re-enter your new passcode";
     self.enterNewPasscodeString = @"Enter your new passcode";
     self.biometricsDetailsString = @"Unlock using Touch ID";
+    self.logoutWarningMessageString = @"When you log out, files from your Offline section will be deleted from your device and ongoing transfers will be cancelled.";
 }
 
 

--- a/Localizations/LTHPasscodeViewController.bundle/Base.lproj/LTHPasscodeViewController.strings
+++ b/Localizations/LTHPasscodeViewController.bundle/Base.lproj/LTHPasscodeViewController.strings
@@ -28,3 +28,21 @@
 "Unlock using Face ID"="Unlock using Face ID";
 /* Text used to explain it is not possible to reuse the same PIN code. Not to be confused with "password". You can find how the Passcode is called in your language in an iOS device settings. */
 "Cannot reuse the same passcode"="Cannot reuse the same passcode";
+/* Button text to change the passcode type. */
+"Passcode Options" = "Passcode Options";
+/* Title to confirm that you want to logout */
+"proceedToLogout" = "Proceed to log out";
+/* Warning message to alert user about logout in My Account section if has offline files and transfers in progress. */
+"When you logout, files from your Offline section will be deleted from your device and ongoing transfers will be cancelled." = "When you log out, files from your Offline section will be deleted from your device and ongoing transfers will be cancelled.";
+/* Button title to cancel something */
+"cancel"="Cancel";
+/* Title of the button which logs out from your account. */
+"logoutLabel"="Log out";
+/* Action text to change to 4-Digit Numeric passcode type. */
+"4-Digit Numeric Code"="4-digit numeric code";
+/* Action text to change to 6-Digit Numeric passcode type. */
+"6-Digit Numeric Code"="6-digit numeric code";
+/* Action text to change to Custom Alphanumeric passcode type. */
+"Custom Alphanumeric Code"="Custom alphanumeric code";
+/* Footer text that explain what will happen if reach the max number of failed attempts */
+"failedAttempstSectionTitle"="You will be logged out and your offline files will be deleted after 10 failed attempts";

--- a/Localizations/LTHPasscodeViewController.bundle/en.lproj/LTHPasscodeViewController.strings
+++ b/Localizations/LTHPasscodeViewController.bundle/en.lproj/LTHPasscodeViewController.strings
@@ -28,3 +28,21 @@
 "Unlock using Face ID"="Unlock using Face ID";
 /* Text used to explain it is not possible to reuse the same PIN code. Not to be confused with "password". You can find how the Passcode is called in your language in an iOS device settings. */
 "Cannot reuse the same passcode"="Cannot reuse the same passcode";
+/* Button text to change the passcode type. */
+"Passcode Options" = "Passcode Options";
+/* Title to confirm that you want to logout */
+"proceedToLogout" = "Proceed to log out";
+/* Warning message to alert user about logout in My Account section if has offline files and transfers in progress. */
+"When you logout, files from your Offline section will be deleted from your device and ongoing transfers will be cancelled." = "When you log out, files from your Offline section will be deleted from your device and ongoing transfers will be cancelled.";
+/* Button title to cancel something */
+"cancel"="Cancel";
+/* Title of the button which logs out from your account. */
+"logoutLabel"="Log out";
+/* Action text to change to 4-Digit Numeric passcode type. */
+"4-Digit Numeric Code"="4-digit numeric code";
+/* Action text to change to 6-Digit Numeric passcode type. */
+"6-Digit Numeric Code"="6-digit numeric code";
+/* Action text to change to Custom Alphanumeric passcode type. */
+"Custom Alphanumeric Code"="Custom alphanumeric code";
+/* Footer text that explain what will happen if reach the max number of failed attempts */
+"failedAttempstSectionTitle"="You will be logged out and your offline files will be deleted after 10 failed attempts";


### PR DESCRIPTION
This PR adds new strings into the PasscodeViewController (base and en localizable string files)

**New added strings:**

```
/* Button text to change the passcode type. */
"Passcode Options" = "Passcode Options";

/* Title to confirm that you want to logout */
"proceedToLogout" = "Proceed to log out";

/* Warning message to alert user about logout in My Account section if has offline files and transfers in progress. */
"When you logout, files from your Offline section will be deleted from your device and ongoing transfers will be cancelled." = "When you log out, files from your Offline section will be deleted from your device and ongoing transfers will be cancelled.";

/* Button title to cancel something */
"cancel"="Cancel";

/* Title of the button which logs out from your account. */
"logoutLabel"="Log out";

/* Action text to change to 4-Digit Numeric passcode type. */
"4-Digit Numeric Code"="4-digit numeric code";

/* Action text to change to 6-Digit Numeric passcode type. */
"6-Digit Numeric Code"="6-digit numeric code";

/* Action text to change to Custom Alphanumeric passcode type. */
"Custom Alphanumeric Code"="Custom alphanumeric code";

/* Footer text that explain what will happen if reach the max number of failed attempts */
"failedAttempstSectionTitle"="You will be logged out and your offline files will be deleted after 10 failed attempts";
```

**Screenshots**
![after-fix-localization-1](https://github.com/rolandleth/LTHPasscodeViewController/assets/144235977/9239da77-6e21-4acf-b310-90ab3259ba22)
![after-fix-localization-2](https://github.com/rolandleth/LTHPasscodeViewController/assets/144235977/d566cec5-bc73-4dd3-bc35-c73420ead581)
![after-fix-localization-3](https://github.com/rolandleth/LTHPasscodeViewController/assets/144235977/ea595860-32ff-44b0-bb88-11fae4218a4c)
![after-fix-localization-4](https://github.com/rolandleth/LTHPasscodeViewController/assets/144235977/24620210-7d57-4e42-96d7-3006abebc81b)
![after-fix-localization-5](https://github.com/rolandleth/LTHPasscodeViewController/assets/144235977/8e69a028-22ef-4b6a-8f3b-2f7ed4094983)


