### PR TITLE
IOS-7679: Logout label localization fixed

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1851,7 +1851,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
         else {
             [self showLockScreenWithAnimation:NO
                                    withLogout:YES
-                               andLogoutTitle:NSLocalizedString(@"logoutLabel", nil)];
+                               andLogoutTitle:LTHPasscodeViewControllerStrings(@"logoutLabel")];
         }
     }
 }


### PR DESCRIPTION
This PR fixes localization issue of Logout Label.

![IMG_FCEF750F6ACC-1](https://github.com/meganz/LTHPasscodeViewController/assets/144235977/d430e0f6-9e1b-41ca-a4b0-61cff6b02372)
