### PR TITLE
T14796259: Fix colors not using the injected one

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -789,7 +789,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     [self.view addSubview: _coverView];
 #endif
     _complexPasscodeOverlayView = [[UIView alloc] initWithFrame:CGRectZero];
-    _complexPasscodeOverlayView.backgroundColor = UIColor.systemBackgroundColor;
+    _complexPasscodeOverlayView.backgroundColor = _backgroundColor;
     _complexPasscodeOverlayView.translatesAutoresizingMaskIntoConstraints = NO;
     [self _setupPasscodeOverlayBorder];
     


### PR DESCRIPTION
The colors is forced to use the `systemBackgroundColor`, we need this to use the `backgroundColor` so that we can change the color of this in MEGA app.


| Before | After |
| --- | --- |
| ![Screenshot 2024-07-31 at 14 17 12](https://github.com/user-attachments/assets/fab5ea83-8fd1-47e2-9e9e-9648fcb0b5f8) | ![Screenshot 2024-07-31 at 14 18 17](https://github.com/user-attachments/assets/4bc85e02-7e6b-4f3f-92c2-16cee769b1a0) |