### PR TITLE
T14796259: Fix failed attempt color also not using the configurable color

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1717,10 +1717,10 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     ? LTHPasscodeViewControllerStrings(@"Cannot reuse the same passcode")
     : LTHPasscodeViewControllerStrings(@"Passcodes did not match. Try again.");
     _newPasscodeEqualsOldPasscode = NO;
-    _failedAttemptLabel.backgroundColor = [UIColor clearColor];
+    _failedAttemptLabel.backgroundColor = _failedAttemptLabelBackgroundColor;
     _failedAttemptLabel.layer.borderWidth = 0;
     _failedAttemptLabel.layer.borderColor = [UIColor clearColor].CGColor;
-    _failedAttemptLabel.textColor = UIColor.systemRedColor;
+    _failedAttemptLabel.textColor = _failedAttemptLabelTextColor;
     _eraseLocalDataLabel.hidden = YES;
     _optionsButton.hidden = NO;
 }


### PR DESCRIPTION
A request was made for the error label to use the red from the design token, but it was already set to use design token colors. Turns out there this one part of the code, where the label colors are set using system colors instead of the configurable one. This PR fixes that.