### PR TITLE
AP-2181: In-App passcode screen - Message "You will be logged out..." is still displayed even after auto logout and re-login

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1599,6 +1599,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     if (_maxNumberOfAllowedFailedAttempts > 0 &&
         _failedAttempts >= _maxNumberOfAllowedFailedAttempts &&
         [self.delegate respondsToSelector: @selector(maxNumberOfFailedAttemptsReached)]) {
+        _failedAttempts = 0;
         [self.delegate maxNumberOfFailedAttemptsReached];
     }
     


### PR DESCRIPTION
## Please explain your changes.

#### What does this implement/fix?

Reset the `_failedAttempts` to 0 when max attempts is reached and going to logout.

#### Why are we making this change?

If we don't reset it, it state is kept the next time we go to the passcode screen, which causes the error

#### What features are impacted?

Enable passcode screen.

#### If the MR has more than 10 files, please provide a valid reason.

## Screenshot/Screen-recording comparisons
|         Before         |           After         |
| ---------------------- | ----------------------- |
| <img src="https://github.com/user-attachments/assets/d2ab8b83-69c8-4264-9a69-4349852d07ca" width=320> | https://mega.nz/file/5aomTQJQ#zToNLnckgIuVTj84yRqXzqK6zn2tRo1NVpKGOBnBOng | 
