### PR TITLE
IOS-10330: Update LTHPasscodeViewController to recreate KM transfer on passcode change

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -236,6 +236,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                      forServiceName:_keychainServiceName
                      updateExisting:YES
                               error:nil];
+    [self recreateKMTransferFile];
 }
 
 
@@ -314,6 +315,8 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     } else {
         _isResetPasscode = NO;
     }
+
+    [self recreateKMTransferFile];
 }
 
 
@@ -348,6 +351,8 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                      forServiceName:_keychainServiceName
                      updateExisting:YES
                               error:nil];
+
+    [self recreateKMTransferFile];
 }
 
 
@@ -468,6 +473,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                      forServiceName:_keychainServiceName
                      updateExisting:YES
                               error:nil];
+    [self recreateKMTransferFile];
 }
 
 

--- a/LTHPasscodeViewController/LTMPasscodeViewController+KMTransfer.swift
+++ b/LTHPasscodeViewController/LTMPasscodeViewController+KMTransfer.swift
@@ -1,0 +1,14 @@
+import MEGAAppPresentation
+
+extension LTHPasscodeViewController {
+    private var isKMTransferEnabled: Bool {
+        DIContainer.featureFlagProvider.isFeatureFlagEnabled(for: .kmTransfer)
+    }
+
+    @objc func recreateKMTransferFile() {
+        guard isKMTransferEnabled else { return }
+        Task {
+            try? await DIContainer.kmTransferUtils.recreateTransferFile()
+        }
+    }
+}


### PR DESCRIPTION
The MR add logic to recreate KM transfer when:
* Add new/update passcode
* Delete passcode
* Change timer duration
* Change allow unlock with biometrics